### PR TITLE
Number format handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ function (_Component) {
         className: "dnone",
         inputValue: parsedValue,
         displayValue: parsedValue.toString()
-      }, _this.proxyOnChangeOnRefWithValue(_this.inputRef, total));
+      }, _this.proxyOnChangeOnRefWithValue(_this.inputRef, parsedValue));
     });
 
     _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "onChangeDisplay", function (val) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,12 +59,12 @@ function (_Component) {
 
     _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "onComplete", function () {
       var total = eval(_this.state.displayValue).toFixed(4);
-      console.log(total);
+      var parsedValue = _this.props.format === 'integer' ? parseInt(total, 10) : parseFloat(total);
 
       _this.setState({
         className: "dnone",
-        inputValue: total,
-        displayValue: total.toString()
+        inputValue: parsedValue,
+        displayValue: parsedValue.toString()
       }, _this.proxyOnChangeOnRefWithValue(_this.inputRef, total));
     });
 
@@ -121,7 +121,7 @@ function (_Component) {
     });
 
     _defineProperty(_assertThisInitialized(_assertThisInitialized(_this)), "handleChange", function (event) {
-      var parsedValue = parseFloat(event.target.value, 10);
+      var parsedValue = _this.props.format === 'integer' ? parseInt(event.target.value, 10) : parseFloat(event.target.value);
       var value = isNaN(parsedValue) ? 0 : parsedValue;
       var stringValue = value.toString();
 

--- a/src/docs/index.jsx
+++ b/src/docs/index.jsx
@@ -7,7 +7,7 @@ function Demo() {
   return (
     <div>
       <h1>Demo with examples of the component</h1>
-      <NumericInput id="myinput" label="Age" name="age"/>
+      <NumericInput id="myinput" label="Age" name="age" format="integer" />
     </div>
   );
 }

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -19,9 +19,11 @@ class NumericInput extends Component {
 
     onComplete = () => {
         var total = eval(this.state.displayValue).toFixed(4);
-        console.log(total)
+        const parsedValue = this.props.format === 'integer'
+            ? parseInt(total, 10)
+            : parseFloat(total);
         this.setState(
-            {className:"dnone", inputValue: total, displayValue: total.toString()},
+            {className:"dnone", inputValue: parsedValue, displayValue: parsedValue.toString()},
             this.proxyOnChangeOnRefWithValue(this.inputRef, total)
         );
     }
@@ -69,7 +71,9 @@ class NumericInput extends Component {
     }
 
     handleChange = (event) => {
-        const parsedValue = parseFloat(event.target.value, 10);
+        const parsedValue = this.props.format === 'integer'
+            ? parseInt(event.target.value, 10)
+            : parseFloat(event.target.value);
         const value = isNaN(parsedValue) ? 0 : parsedValue;
         const stringValue = value.toString();
         this.setState(

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -24,7 +24,7 @@ class NumericInput extends Component {
             : parseFloat(total);
         this.setState(
             {className:"dnone", inputValue: parsedValue, displayValue: parsedValue.toString()},
-            this.proxyOnChangeOnRefWithValue(this.inputRef, total)
+            this.proxyOnChangeOnRefWithValue(this.inputRef, parsedValue)
         );
     }
 


### PR DESCRIPTION
Consider handling numbers as integers.
- New prop: `format`. If value is "integer", use `parseInt` instead of `parseFloat`

TODO:
better handle possible values of `format`.